### PR TITLE
Pokedex search term upgrade

### DIFF
--- a/app/src/main/graphql/PokemonListGraphQlQuery.graphql
+++ b/app/src/main/graphql/PokemonListGraphQlQuery.graphql
@@ -1,5 +1,5 @@
-query PokemonListGraphQlQuery($searchTerm :String, $offset : Int, $pageSize: Int) {
-    pokemonItem: pokemon_v2_pokemonspecies(where: {name: {_regex: $searchTerm}}, offset: $offset, limit: $pageSize, order_by: {id: asc}) {
+query PokemonListGraphQlQuery($searchTerm :String,$notStartsWith: String, $offset : Int, $pageSize: Int) {
+    pokemonItem: pokemon_v2_pokemonspecies(where: {_and: {name: {_ilike: $searchTerm}}, name: {_nlike: $notStartsWith}}, offset: $offset, limit: $pageSize, order_by: {id: asc}) {
         name
         id
         pokemon_color_id

--- a/app/src/main/java/com/gustavoeliseu/pokedex/network/pagingsource/PokemonPagingSource.kt
+++ b/app/src/main/java/com/gustavoeliseu/pokedex/network/pagingsource/PokemonPagingSource.kt
@@ -42,10 +42,8 @@ class PokemonPagingSource(private val searchTerm: String,private val response: s
             offset = Optional.present(currentNextPage),
             pageSize = Optional.present(PAGE_SIZE)
         )
-        Log.e("testeee $isSearching", "$isSearching / $currentSearchTerm / $startsWith")
 
         val pokeList = response.invoke(query)?.pokemonItem ?: listOf()
-
         val prevKey = if (currentNextPage > 0) currentNextPage - PAGE_SIZE else null
         val nextKey = when{
             pokeList.size> PAGE_SIZE-1 ->{currentNextPage + PAGE_SIZE}

--- a/app/src/main/java/com/gustavoeliseu/pokedex/network/pagingsource/PokemonPagingSource.kt
+++ b/app/src/main/java/com/gustavoeliseu/pokedex/network/pagingsource/PokemonPagingSource.kt
@@ -3,11 +3,19 @@ package com.gustavoeliseu.pokedex.network.pagingsource
 import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.apollographql.apollo3.api.Optional
 import com.gustavoeliseu.pokedex.PokemonListGraphQlQuery
 import com.gustavoeliseu.pokedex.utils.Const.PAGE_SIZE
 
-class PokemonPagingSource(private val response: suspend (Int) -> PokemonListGraphQlQuery.Data?) :
+class PokemonPagingSource(private val searchTerm: String,private val response: suspend (PokemonListGraphQlQuery) -> PokemonListGraphQlQuery.Data?) :
     PagingSource<Int, PokemonListGraphQlQuery.PokemonItem>() {
+
+    //TODO - CLEAN THIS CLASS SO IT CAN BE RE-UTILIZED FOR OTHER PURPOSES, SOLID
+    //THIS CLASS IS TOO SPECIFIC, SHOULD BE MORE GENERIC SO IT CAN BE RE-UTILIZED FOR PART 3(tier search)
+    private var isSearching = false
+    private var nextPage = 0
+    private var currentSearchTerm: String? = null
+
     override fun getRefreshKey(state: PagingState<Int, PokemonListGraphQlQuery.PokemonItem>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
@@ -16,17 +24,46 @@ class PokemonPagingSource(private val response: suspend (Int) -> PokemonListGrap
     }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, PokemonListGraphQlQuery.PokemonItem> {
-        val nextPage = params.key ?: 0
-        val pokeList = response.invoke((nextPage))?.pokemonItem ?: listOf()
-        val prevKey = if (nextPage > 0) nextPage - PAGE_SIZE else null
-        val nextKey =
-            if (pokeList.isNotEmpty() && pokeList.size > PAGE_SIZE - 1) nextPage + PAGE_SIZE else null
-        if (pokeList.isEmpty()) return LoadResult.Error(Exception())
+        val localSearchTerm = if (isSearching && searchTerm.isNotEmpty()) "%$searchTerm" else searchTerm
+        val startsWith = if (isSearching && searchTerm.isNotEmpty()) searchTerm else ""
+
+        // Reset nextPage only when the search term changes
+        if (localSearchTerm != currentSearchTerm) {
+            nextPage = 0
+            currentSearchTerm = localSearchTerm
+        }
+
+        val currentNextPage = nextPage
+        nextPage = currentNextPage + PAGE_SIZE
+        // Attempt to load from the query
+        val query = PokemonListGraphQlQuery(
+            searchTerm = Optional.present(currentSearchTerm),
+            notStartsWith = Optional.present(startsWith),
+            offset = Optional.present(currentNextPage),
+            pageSize = Optional.present(PAGE_SIZE)
+        )
+        Log.e("testeee $isSearching", "$isSearching / $currentSearchTerm / $startsWith")
+
+        val pokeList = response.invoke(query)?.pokemonItem ?: listOf()
+
+        val prevKey = if (currentNextPage > 0) currentNextPage - PAGE_SIZE else null
+        val nextKey = when{
+            pokeList.size> PAGE_SIZE-1 ->{currentNextPage + PAGE_SIZE}
+            pokeList.size < PAGE_SIZE-1 && searchTerm.isNotEmpty() &&!isSearching->{0}
+            else-> null
+        }
+
+        if (pokeList.isEmpty() && searchTerm.isNotEmpty() && !isSearching) {
+            // Switch to searching if no results found
+            isSearching = true
+            nextPage= 0
+            return load(params)
+        }
+
         return LoadResult.Page(
-            data = pokeList ?: listOf(),
+            data = pokeList,
             prevKey = prevKey,
             nextKey = nextKey
         )
     }
-
 }

--- a/app/src/main/java/com/gustavoeliseu/pokedex/network/repository/PokemonRepositoryImpl.kt
+++ b/app/src/main/java/com/gustavoeliseu/pokedex/network/repository/PokemonRepositoryImpl.kt
@@ -41,14 +41,10 @@ class PokemonRepositoryImpl @Inject constructor(
     private fun createPagingSource(
         searchTyped: String
     ): PokemonPagingSource {
-        return PokemonPagingSource { offset ->
+        return PokemonPagingSource(searchTerm = "$searchTyped%") { mQuery ->
             try {
                 pokemonApi.query(
-                    PokemonListGraphQlQuery(
-                        searchTerm = Optional.present(searchTyped),
-                        offset = Optional.present(offset),
-                        pageSize = Optional.present(PAGE_SIZE)
-                    )
+                    mQuery
                 ).refetchPolicy(FetchPolicy.CacheFirst).execute().data
             } catch (exception: ApolloException) {
                 SafeCrashlyticsUtil.logException(exception)


### PR DESCRIPTION
Changes the list search so it searchs first pokemons that start with the searchTerm, then pokemons that have that search in the name:

Example for "da":
first goes to : Darkrai, Daruma...
then: Kadabra, Rapidash...